### PR TITLE
[semver:skip] Update link to CircleCI Orb Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Easily test, build and run your Rust orbs on CircleCI.
 
 ## Resources
 
-[CircleCI Orb Registry Page](https://circleci.com/orbs/registry/orb/circleci/rust-orb) - The official registry page of this orb for all versions, executors, commands, and jobs described.
+[CircleCI Orb Registry Page](https://circleci.com/developer/orbs/orb/circleci/rust) - The official registry page of this orb for all versions, executors, commands, and jobs described.
 [CircleCI Orb Docs](https://circleci.com/docs/2.0/orb-intro/#section=configuration) - Docs for using and creating CircleCI Orbs.
 
 ### How to Contribute


### PR DESCRIPTION
The previous link was 404-ing, so this updates the link to this orbs registry page to
a current location.