### PR TITLE
[semver:minor] Setup Cargo environment in $BASH_ENV

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -14,3 +14,6 @@ steps:
       command: <<include(scripts/install.sh)>>
       environment:
         RUST_VERSION: <<parameters.version>>
+  - run:
+      name: Setting up Cargo environment in \$BASH_ENV
+      run: echo 'source $HOME/.cargo/env' >> $BASH_ENV

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -16,4 +16,4 @@ steps:
         RUST_VERSION: <<parameters.version>>
   - run:
       name: Setting up Cargo environment in \$BASH_ENV
-      run: echo 'source $HOME/.cargo/env' >> $BASH_ENV
+      command: echo 'source $HOME/.cargo/env' >> $BASH_ENV

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -15,5 +15,5 @@ steps:
       environment:
         RUST_VERSION: <<parameters.version>>
   - run:
-      name: Setting up Cargo environment in \$BASH_ENV
+      name: Setting up Cargo environment in $BASH_ENV
       command: echo 'source $HOME/.cargo/env' >> $BASH_ENV


### PR DESCRIPTION
Ensure that the Cargo environment is installed into CircleCI's [$BASH_ENV]
so later `run` steps which use `cargo` commands will have it in their path.

This isn't normally necessary since the Rust installer does add `source`
instructions into the "known" shell initialization scripts (e.g., `.bashrc`,
`.zshrc`, etc.), but since CircleCI necessitates using a special file at
a path specified in the environment by `$BASH_ENV`, this isn't handled
automatically.

I would be happy to believe that I'm doing something wrong, but I found it
necessary to do this in order to allow subsequent shells to invoke `cargo`
(or `rustc`, etc.) commands if I did not make this adjustment to `$BASH_ENV`.

See an example here in https://github.com/apollographql/federation/blob/df94502f81d617b8faa7c7f9efac711a3f76f760/.circleci/config.yml#L23-L26.

[$BASH_ENV]: https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-shell-command