### PR TITLE
[semver:skip] Fix misspelling in README Contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ We welcome [issues](https://github.com/CircleCI-Public/rust-orb/issues) to and [
 ### How to Publish
 * Create and push a branch with your new features.
 * When ready to publish a new production version, create a Pull Request from fore _feature branch_ to `master`.
-* The title of the pull request must contain a special semver tag: `[semver:<segement>]` where `<segment>` is replaced by one of the following values.
+* The title of the pull request must contain a special semver tag: `[semver:<segment>]` where `<segment>` is replaced by one of the following values.
 
 | Increment | Description|
 | ----------| -----------|


### PR DESCRIPTION
I'm assuming this was cargo-culted / copy-pasted from somewhere else where it might be good to also fix this, but I'm not sure where that would be, so I'm updating it here where I encountered it. 😉 