### PR TITLE
[semver:minor] Add working_directory support

### DIFF
--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -18,6 +18,10 @@ parameters:
     description: Cache version to use - increment this to build a fresh cache.
     type: string
     default: "v1"
+  working_directory:
+    type: string
+    default: "~/project"
+    description: Path to the directory containing your Cargo.lock file. Not needed if Cargo.lock lives in the root.
 
 steps:
   - when:
@@ -31,6 +35,7 @@ steps:
   - run:
       name: Cargo Build <<parameters.crate>>
       command: cargo build <<parameters.crate>> <<#parameters.release>>--release<</parameters.release>>
+      working_directory: <<parameters.working_directory>>
   - when:
       condition: <<parameters.with_cache>>
       steps:

--- a/src/commands/cargo-run.yml
+++ b/src/commands/cargo-run.yml
@@ -14,6 +14,10 @@ parameters:
     description: Cache version to use - increment this to build a fresh cache.
     type: string
     default: "v1"
+  working_directory:
+    type: string
+    default: "~/project"
+    description: Path to the directory containing your Cargo.lock file. Not needed if Cargo.lock lives in the root.
 
 steps:
   - when:
@@ -26,6 +30,7 @@ steps:
               - cargo-
   - run:
       command: cargo run <<parameters.package>>
+      working_directory: <<parameters.working_directory>>
   - when:
       condition: <<parameters.with_cache>>
       steps:

--- a/src/commands/clippy.yml
+++ b/src/commands/clippy.yml
@@ -14,6 +14,10 @@ parameters:
     description: Cache version to use - increment this to build a fresh cache.
     type: string
     default: "v1"
+  working_directory:
+    type: string
+    default: "~/project"
+    description: Path to the directory containing your Cargo.lock file. Not needed if Cargo.lock lives in the root.
 
 steps:
   - when:
@@ -30,6 +34,7 @@ steps:
   - run:
       name: Run Clippy
       command: cargo clippy <<parameters.flags>>
+      working_directory: <<parameters.working_directory>>
   - when:
       condition: <<parameters.with_cache>>
       steps:

--- a/src/commands/format.yml
+++ b/src/commands/format.yml
@@ -14,6 +14,10 @@ parameters:
     description: Cache version to use - increment this to build a fresh cache.
     type: string
     default: "v1"
+  working_directory:
+    type: string
+    default: "~/project"
+    description: Path to the directory containing your Cargo.lock file. Not needed if Cargo.lock lives in the root.
 
 steps:
   - when:
@@ -30,6 +34,7 @@ steps:
   - run:
       name: Run fmt
       command: cargo <<#parameters.nightly-toolchain>>+nightly<</parameters.nightly-toolchain>> fmt
+      working_directory: <<parameters.working_directory>>
   - when:
       condition: <<parameters.with_cache>>
       steps:

--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -14,6 +14,10 @@ parameters:
     description: Cache version to use - increment this to build a fresh cache.
     type: string
     default: "v1"
+  working_directory:
+    type: string
+    default: "~/project"
+    description: Path to the directory containing your Cargo.lock file. Not needed if Cargo.lock lives in the root.
 
 steps:
   - when:
@@ -26,6 +30,7 @@ steps:
               - cargo-
   - run:
       command: cargo test <<parameters.package>>
+      working_directory: <<parameters.working_directory>>
   - when:
       condition: <<parameters.with_cache>>
       steps:

--- a/src/jobs/lint-test-build.yml
+++ b/src/jobs/lint-test-build.yml
@@ -22,6 +22,10 @@ parameters:
     description: Whether to build the binary for release or debug.
     type: boolean
     default: false
+  working_directory:
+    type: string
+    default: "~/project"
+    description: Path to the directory containing your Cargo.lock file. Not needed if Cargo.lock lives in the root.
 
 executor:
   name: default
@@ -41,11 +45,14 @@ steps:
   - clippy:
       flags: <<parameters.clippy_arguments>>
       with_cache: false
+      working_directory: <<parameters.working_directory>>
   - test:
       with_cache: false
+      working_directory: <<parameters.working_directory>>
   - build:
       release: <<parameters.release>>
       with_cache: false
+      working_directory: <<parameters.working_directory>>
   - when:
       condition: <<parameters.with_cache>>
       steps:


### PR DESCRIPTION
add `working_directory` parameters to all commands for which it makes sense and to the `lint-test-build` job.

this allows using the orb in #monorepos where a rust project is a subdirectory