### PR TITLE
[semver:minor] Fix format job to fail if formatting is wrong

### DIFF
--- a/src/commands/format.yml
+++ b/src/commands/format.yml
@@ -33,7 +33,7 @@ steps:
       command: rustup component add rustfmt <<#parameters.nightly-toolchain>>--toolchain nightly<</parameters.nightly-toolchain>>
   - run:
       name: Run fmt
-      command: cargo <<#parameters.nightly-toolchain>>+nightly<</parameters.nightly-toolchain>> fmt
+      command: cargo <<#parameters.nightly-toolchain>>+nightly<</parameters.nightly-toolchain>> fmt -- --check
       working_directory: <<parameters.working_directory>>
   - when:
       condition: <<parameters.with_cache>>


### PR DESCRIPTION
`cargo fmt` only changes the files in place, it doesn't generate an error or any text about what formatting issues there were. So it just silently "fixes" the problem and always passes.

Add the `--check` flag to `rustfmt` which will fail and display the formatting issues. I confirmed that this change works (by failing a check if formatting is wrong) in my own custom config.