### PR TITLE
[semver:minor] Have `cache_version` be the prefix in all cases.

### DIFF
--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -29,9 +29,7 @@ steps:
       steps:
         - restore_cache:
             keys:
-              - cargo-{{ checksum "Cargo.lock" }}-<<parameters.cache_version>>
-              - cargo-{{ checksum "Cargo.lock" }}
-              - cargo-
+              - cargo-<<parameters.cache_version>>-{{ checksum "Cargo.lock" }}
   - run:
       name: Cargo Build <<parameters.crate>>
       command: cargo build <<parameters.crate>> <<#parameters.release>>--release<</parameters.release>>
@@ -40,6 +38,6 @@ steps:
       condition: <<parameters.with_cache>>
       steps:
         - save_cache:
-            key: cargo-{{ checksum "Cargo.lock" }}-<<parameters.cache_version>>
+            key: cargo-<<parameters.cache_version>>-{{ checksum "Cargo.lock" }}
             paths:
               - ~/.cargo

--- a/src/commands/cargo-run.yml
+++ b/src/commands/cargo-run.yml
@@ -25,9 +25,7 @@ steps:
       steps:
         - restore_cache:
             keys:
-              - cargo-{{ checksum "Cargo.lock" }}-<<parameters.cache_version>>
-              - cargo-{{ checksum "Cargo.lock" }}
-              - cargo-
+              - cargo-<<parameters.cache_version>>-{{ checksum "Cargo.lock" }}
   - run:
       command: cargo run <<parameters.package>>
       working_directory: <<parameters.working_directory>>
@@ -35,6 +33,6 @@ steps:
       condition: <<parameters.with_cache>>
       steps:
         - save_cache:
-            key: cargo-{{ checksum "Cargo.lock" }}-<<parameters.cache_version>>
+            key: cargo-<<parameters.cache_version>>-{{ checksum "Cargo.lock" }}
             paths:
               - ~/.cargo

--- a/src/commands/clippy.yml
+++ b/src/commands/clippy.yml
@@ -25,9 +25,7 @@ steps:
       steps:
         - restore_cache:
             keys:
-              - cargo-{{ checksum "Cargo.lock" }}-<<parameters.cache_version>>
-              - cargo-{{ checksum "Cargo.lock" }}
-              - cargo-
+              - cargo-<<parameters.cache_version>>-{{ checksum "Cargo.lock" }}
   - run:
       name: Install Clippy
       command: rustup component add clippy
@@ -39,6 +37,6 @@ steps:
       condition: <<parameters.with_cache>>
       steps:
         - save_cache:
-            key: cargo-{{ checksum "Cargo.lock" }}-<<parameters.cache_version>>
+            key: cargo-<<parameters.cache_version>>-{{ checksum "Cargo.lock" }}
             paths:
               - ~/.cargo

--- a/src/commands/format.yml
+++ b/src/commands/format.yml
@@ -25,9 +25,7 @@ steps:
       steps:
         - restore_cache:
             keys:
-              - cargo-{{ checksum "Cargo.lock" }}-<<parameters.cache_version>>
-              - cargo-{{ checksum "Cargo.lock" }}
-              - cargo-
+              - cargo-<<parameters.cache_version>>-{{ checksum "Cargo.lock" }}
   - run:
       name: Install fmt
       command: rustup component add rustfmt <<#parameters.nightly-toolchain>>--toolchain nightly<</parameters.nightly-toolchain>>
@@ -39,6 +37,6 @@ steps:
       condition: <<parameters.with_cache>>
       steps:
         - save_cache:
-            key: cargo-{{ checksum "Cargo.lock" }}-<<parameters.cache_version>>
+            key: cargo-<<parameters.cache_version>>-{{ checksum "Cargo.lock" }}
             paths:
               - ~/.cargo

--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -25,9 +25,7 @@ steps:
       steps:
         - restore_cache:
             keys:
-              - cargo-{{ checksum "Cargo.lock" }}-<<parameters.cache_version>>
-              - cargo-{{ checksum "Cargo.lock" }}
-              - cargo-
+              - cargo-<<parameters.cache_version>>-{{ checksum "Cargo.lock" }}
   - run:
       command: cargo test <<parameters.package>>
       working_directory: <<parameters.working_directory>>
@@ -35,6 +33,6 @@ steps:
       condition: <<parameters.with_cache>>
       steps:
         - save_cache:
-            key: cargo-{{ checksum "Cargo.lock" }}-<<parameters.cache_version>>
+            key: cargo-<<parameters.cache_version>>-{{ checksum "Cargo.lock" }}
             paths:
               - ~/.cargo

--- a/src/jobs/lint-test-build.yml
+++ b/src/jobs/lint-test-build.yml
@@ -38,9 +38,7 @@ steps:
       steps:
         - restore_cache:
             keys:
-              - cargo-{{ checksum "Cargo.lock" }}-<<parameters.cache_version>>
-              - cargo-{{ checksum "Cargo.lock" }}
-              - cargo-
+              - cargo-<<parameters.cache_version>>-{{ checksum "Cargo.lock" }}
   # Cache is likely restored above, so we don't bother beyond that.
   - clippy:
       flags: <<parameters.clippy_arguments>>
@@ -57,6 +55,6 @@ steps:
       condition: <<parameters.with_cache>>
       steps:
         - save_cache:
-            key: cargo-{{ checksum "Cargo.lock" }}-<<parameters.cache_version>>
+            key: cargo-<<parameters.cache_version>>-{{ checksum "Cargo.lock" }}
             paths:
               - ~/.cargo


### PR DESCRIPTION
This gives the `cache_version` the control it needs to effectively bust a cache.  Without having the version _earlier_ in the cache key, stale caches can still happen since CircleCI falls back to less and less specific versions of the cache from right to left.

Also, this removes the possibility of it ever falling back to an un-versioned cache which opens the door to using a permanently bricked cache without control over bumping the version, or allows the caches to blur between platforms (e.g., a Unix cache using a macOS cache).

This is also per the advice of the CircleCI documentation:

  https://circleci.com/docs/2.0/caching/#clearing-cache

Fixes: https://github.com/CircleCI-Public/rust-orb/issues/10