### PR TITLE
[semver:minor] Clippy job should fail if it issues warnings

### DIFF
--- a/src/commands/clippy.yml
+++ b/src/commands/clippy.yml
@@ -4,7 +4,7 @@ description: >
 parameters:
   flags:
     description: Additional flags to pass along to Clippy.
-    default: "--all --all-targets"
+    default: "--all --all-targets -- --deny warnings"
     type: string
   with_cache:
     description: Whether to restore and save the cache or not - set to no if running multiple commands in one job.


### PR DESCRIPTION
Warnings from clippy do not return an error code. So we convert all warnings to "deny".

This looks like a "bugfix" to me, so I'm tempted to use semver:patch. But many folks will see jobs start to fail, so maybe it's worth bumping it up to a minor.