### PR TITLE
[semver:major] Update default Rust version from 1.49.0 to 1.56.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+ - Default Rust version updated from 1.49.0 to 1.56.0
+
 ## [1.4.0] - 2021-04-13
 ### Added
 

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -5,7 +5,7 @@ parameters:
   tag:
     description: Tag of the Rust image to use.
     type: string
-    default: 1.49.0
+    default: 1.56.0
 
 docker:
   - image: cimg/rust:<<parameters.tag>>

--- a/src/jobs/lint-test-build.yml
+++ b/src/jobs/lint-test-build.yml
@@ -5,7 +5,7 @@ parameters:
   version:
     description: Version of Rust executor to utilize.
     type: string
-    default: 1.49.0
+    default: 1.56.0
   with_cache:
     description: Whether to restore and save the cache or not - set to no if running multiple commands in one job.
     type: boolean


### PR DESCRIPTION
Changelogs:
https://blog.rust-lang.org/2021/02/11/Rust-1.50.0.html
https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html
https://blog.rust-lang.org/2021/05/06/Rust-1.52.0.html
https://blog.rust-lang.org/2021/05/10/Rust-1.52.1.html
https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html
https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html
https://blog.rust-lang.org/2021/09/09/Rust-1.55.0.html
https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html
