### PR TITLE
ci: migrate to Orb Tools 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 setup: true
 orbs:
-  orb-tools: circleci/orb-tools@11.5
+  orb-tools: circleci/orb-tools@12.0
   shellcheck: circleci/shellcheck@3.1
 
 filters: &filters
@@ -16,20 +16,14 @@ workflows:
       - orb-tools/pack:
           filters: *filters
       - orb-tools/review:
+          exclude: RC010
           filters: *filters
       - shellcheck/check:
           filters: *filters
-      - orb-tools/publish:
-          orb-name: circleci/rust
-          vcs-type: << pipeline.project.type >>
-          requires:
-            [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
-          # Use a context to hold your publishing token.
-          context: orb-publisher
-          filters: *filters
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:
-          pipeline-number: << pipeline.number >>
-          vcs-type: << pipeline.project.type >>
-          requires: [orb-tools/publish]
+          orb_name: rust
+          pipeline_number: << pipeline.number >>
+          vcs_type: << pipeline.project.type >>
+          requires: [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           filters: *filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,11 +1,17 @@
 version: 2.1
 orbs:
-  rust: circleci/rust@dev:<<pipeline.git.revision>>
-  orb-tools: circleci/orb-tools@11.5
+  rust: {}
+  orb-tools: circleci/orb-tools@12.0
 
 filters: &filters
   tags:
     only: /.*/
+
+release-filters: &release-filters
+  branches:
+    ignore: /.*/
+  tags:
+    only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
 
 jobs:
   integration-test_install:
@@ -41,19 +47,17 @@ workflows:
           working_directory: /home/circleci/project/sample
           filters: *filters
       - orb-tools/pack:
-          filters: *filters
+          filters: *release-filters
       - orb-tools/publish:
-          orb-name: circleci/rust
-          vcs-type: << pipeline.project.type >>
-          pub-type: production
+          orb_name: circleci/rust
+          vcs_type: << pipeline.project.type >>
+          pub_type: production
+          enable_pr_comment: true
+          github_token: GHI_TOKEN
           requires:
             - orb-tools/pack
             - integration-test_install
             - integration-test_test-lint-build
             - rust/lint-test-build
           context: orb-publisher
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+          filters: *release-filters


### PR DESCRIPTION
## Description

This PR updates the Rust Orb to the new major version of Orb Tools.

## Changes

The comprehensive list of changes can be found below.

### Changes in `.circleci/config.yml`:

1. Update the orb-tools version from 11.4 to 12.0.
1. Move the job requirement list from `orb-tools/publish` to `orb-tools/continue`.
1. Remove the `orb-tools/publish` job since development versions are no longer necessary.
1. Add the new `orb_name` parameter in `orb-tools/continue`.
1. Rename the `orb-tools/continue` job parameters to comply with the new snake case standard.
   - `orb_name`, `pipeline_number` and `vcs_type`.

### Changes in `.circleci/test-deploy.yml`:

1. Update the orb-tools version from 11.4 to 12.0.
1. Remove the `rust: circleci/rust@dev:<<pipeline.git.revision>>` line, and replace it with `rust: {}`.
1. Rename the `orb-tools/publish` job parameters to comply with the new snake case standard.
   - `orb_name`, `vcs_type`, `pub_type`, `enable_pr_comment` and `github_token`.
1. Change the `orb-tools/pack` filter to trigger only on tagged releases.