### PR TITLE
fix: Don't default to nightly in format.sh (#24)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 setup: true
 orbs:
-  orb-tools: circleci/orb-tools@12.0
-  shellcheck: circleci/shellcheck@3.1
+  orb-tools: circleci/orb-tools@12.3
+  shellcheck: circleci/shellcheck@3.2
 
 filters: &filters
   tags:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -56,7 +56,8 @@ workflows:
           filters: *filters
       - integration-test_test-lint-build:
           name: integration-lint-build-cache-<<matrix.with_cache>>-toolchain-<<matrix.nightly-toolchain>>
-          matrix:
+          matrix: 
+            name: integration-test-matrix
             parameters:
               with_cache: [true, false]
               nightly-toolchain: [true, false]

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -22,8 +22,10 @@ jobs:
   integration-test_test-lint-build:
     parameters:
       nightly-toolchain:
+        default: false
         type: boolean
       with_cache:
+        default: false
         type: boolean
     executor:
       name: rust/default
@@ -50,7 +52,10 @@ workflows:
       - integration-test_install:
           filters: *filters
       - integration-test_test-lint-build:
-          name: integration-test_test-lint-build|
+          name: integration-test_test-lint-build
+          filters: *filters
+      - integration-test_test-lint-build:
+          name: integration-lint-build-cache-<<matrix.with_cache>>-toolchain-<<matrix.nightly-toolchain>>
           matrix:
             alias: integration-test_test-lint-build
             parameters:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -57,7 +57,6 @@ workflows:
       - integration-test_test-lint-build:
           name: integration-lint-build-cache-<<matrix.with_cache>>-toolchain-<<matrix.nightly-toolchain>>
           matrix:
-            alias: integration-test_test-lint-build
             parameters:
               with_cache: [true, false]
               nightly-toolchain: [true, false]

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -52,7 +52,6 @@ workflows:
       - integration-test_install:
           filters: *filters
       - integration-test_test-lint-build:
-          name: integration-test_test-lint-build
           filters: *filters
       - integration-test_test-lint-build:
           name: integration-lint-build-cache-<<matrix.with_cache>>-toolchain-<<matrix.nightly-toolchain>>
@@ -76,7 +75,7 @@ workflows:
           requires:
             - orb-tools/pack
             - integration-test_install
-            - integration-test_test-lint-build
+            - integration-test-matrix
             - rust/lint-test-build
           context: orb-publisher
           filters: *release-filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -56,7 +56,7 @@ workflows:
       - integration-test_test-lint-build:
           name: integration-lint-build-cache-<<matrix.with_cache>>-toolchain-<<matrix.nightly-toolchain>>
           matrix: 
-            name: integration-test-matrix
+            alias: integration-test-matrix
             parameters:
               with_cache: [true, false]
               nightly-toolchain: [true, false]

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -50,7 +50,7 @@ workflows:
       - integration-test_install:
           filters: *filters
       - integration-test_test-lint-build:
-          name: integration-lint-build-cache-<<matrix.with_cache>>-toolchain-<<matrix.nightly-toolchain>>
+          name: integration-test_test-lint-build|
           matrix:
             alias: integration-test_test-lint-build
             parameters:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   rust: {}
-  orb-tools: circleci/orb-tools@12.0
+  orb-tools: circleci/orb-tools@12.3
 
 filters: &filters
   tags:
@@ -20,6 +20,11 @@ jobs:
     steps:
       - rust/install
   integration-test_test-lint-build:
+    parameters:
+      nightly-toolchain:
+        type: boolean
+      with_cache:
+        type: boolean
     executor:
       name: rust/default
     steps:
@@ -27,13 +32,16 @@ jobs:
       - run:
           name: Reorganize directory structure
           command: mv sample ../sample; cd ..; rm -rf project; mv sample project
+      - rust/format:
+          with_cache: <<parameters.with_cache>>
+          nightly-toolchain: <<parameters.nightly-toolchain>>
       - rust/test
       - rust/clippy:
-          with_cache: false
+          with_cache: <<parameters.with_cache>>
       - rust/build:
-          with_cache: false
+          with_cache: <<parameters.with_cache>>
       - rust/cargo-run:
-          with_cache: false
+          with_cache: <<parameters.with_cache>>
 
 workflows:
   test-deploy:
@@ -42,6 +50,12 @@ workflows:
       - integration-test_install:
           filters: *filters
       - integration-test_test-lint-build:
+          name: integration-lint-build-cache-<<matrix.with_cache>>-toolchain-<<matrix.nightly-toolchain>>
+          matrix:
+            alias: integration-test_test-lint-build
+            parameters:
+              with_cache: [true, false]
+              nightly-toolchain: [true, false]
           filters: *filters
       - rust/lint-test-build:
           working_directory: /home/circleci/project/sample

--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -2,7 +2,7 @@
 mod tests {
     #[test]
     fn it_works() {
-    	let add = 1 + 2;
+        let add = 1 + 2;
         assert_eq!(add, 3);
     }
 }

--- a/src/scripts/format.sh
+++ b/src/scripts/format.sh
@@ -3,7 +3,7 @@
 rustup_args=()
 cargo_args=()
 
-if [ "$ORB_VAL_NIGHTLY_TOOLCHAIN" ]; then
+if [ "$ORB_VAL_NIGHTLY_TOOLCHAIN" = "true" ]; then
     rustup_args+=(--toolchain nightly)
     cargo_args+=(+nightly)
 fi


### PR DESCRIPTION
Fixes #24

The issue arises because the environment variable `ORB_VAL_NIGHTLY_TOOLCHAIN` defaults to "false" as a string, which Bash considers true.